### PR TITLE
src: message: Fix: Checksum split payload_lenght and msg_id into two …

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -78,8 +78,14 @@ impl ProtocolMessage {
         let mut checksum: u16 = 0;
         checksum += HEADER[0] as u16;
         checksum += HEADER[1] as u16;
-        checksum += self.payload_length;
-        checksum += self.message_id;
+        self.payload_length
+            .to_le_bytes()
+            .iter()
+            .for_each(|byte| checksum += *byte as u16);
+        self.message_id
+            .to_le_bytes()
+            .iter()
+            .for_each(|byte| checksum += *byte as u16);
         checksum += self.src_device_id as u16;
         checksum += self.dst_device_id as u16;
         for &byte in &self.payload {


### PR DESCRIPTION
Fix CRC calculus, 
payload_lenght and msg_id should be splited into 2 different bytes for the sum.

Fixed issues for PIng1D msgs.