### PR TITLE
Add tokio codec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ quote = "1.0"
 proc-macro2 = "1.0.24"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.64"
+
+[features]
+local_runner = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,12 @@ build = "build/main.rs"
 
 [dependencies]
 bytes = "1.3.0"
+tokio-util = { version = "0.6.3", features = ["codec"] }
+
+[dev-dependencies]
+tokio-serial = "5.4.4"
+tokio = { version = "1.37.0", features = ["full"] }
+futures = "0.3.30"
 
 [build-dependencies]
 convert_case = "0.6.0"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,0 +1,113 @@
+use crate::{decoder::Decoder as PingDecoder, error::PingError, message::ProtocolMessage};
+use bytes::{Buf, BytesMut};
+use tokio_util::codec::{Decoder, Encoder};
+
+pub struct PingCodec {
+    decoder: PingDecoder,
+}
+
+impl PingCodec {
+    pub fn new() -> Self {
+        PingCodec {
+            decoder: PingDecoder::new(),
+        }
+    }
+}
+
+impl Decoder for PingCodec {
+    type Item = ProtocolMessage;
+    type Error = PingError;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        let decoder = &mut self.decoder;
+        let mut consumed = 0;
+
+        loop {
+            let Some(byte) = src.get(consumed) else {
+                return Ok(None);
+            };
+
+            match decoder.parse_byte(*byte) {
+                crate::decoder::DecoderResult::InProgress => {
+                    consumed += 1;
+                    if consumed == src.len() {
+                        src.advance(consumed)
+                    }
+                }
+                crate::decoder::DecoderResult::Success(msg) => {
+                    src.advance(consumed + 1);
+                    return Ok(Some(msg));
+                }
+                crate::decoder::DecoderResult::Error(e) => {
+                    src.advance(consumed + 1);
+                    return Err(PingError::ParseError(e));
+                }
+            }
+        }
+    }
+}
+
+impl Encoder<ProtocolMessage> for PingCodec {
+    type Error = PingError;
+
+    fn encode(&mut self, item: ProtocolMessage, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        dst.extend_from_slice(&item.serialized());
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common;
+
+    #[test]
+    fn test_ping_codec() {
+        let mut codec = PingCodec::new();
+
+        // Define GeneralRequest Buffer
+        let buffer: Vec<u8> = vec![
+            0x42, 0x52, 0x02, 0x00, // payload length
+            0x06, 0x00, // message id
+            0x00, 0x00, // src and dst id
+            0x05, 0x00, // payload
+            0xa1, 0x00, // crc
+        ];
+        let mut bytes_mut = BytesMut::new();
+        bytes_mut.extend_from_slice(&buffer);
+
+        // Define equivalent ProtocolMessage
+        let request =
+            common::Messages::GeneralRequest(common::GeneralRequestStruct { requested_id: 5 });
+        let mut package = crate::message::ProtocolMessage::new();
+        package.set_message(&request);
+
+        // Decode the buffer
+        let decoded_message = codec.decode(&mut bytes_mut).unwrap().unwrap();
+
+        // Assert that the decoded message matches the expected PingMessage
+        assert_eq!(decoded_message, package);
+
+        // Re-test with a wrong CRC
+        let wrong_buffer: Vec<u8> = vec![
+            0x42, 0x52, 0x02, 0x00, // payload length
+            0x06, 0x00, // message id
+            0x00, 0x00, // src and dst id
+            0x05, 0x00, // payload
+            0xa1, 0x01, // wrong crc
+        ];
+        let mut wrong_bytes_mut = BytesMut::new();
+        wrong_bytes_mut.extend_from_slice(&wrong_buffer);
+
+        // Decode the buffer and test ParseError
+        let decoded_message = codec.decode(&mut wrong_bytes_mut);
+
+        assert!(matches!(decoded_message, Err(PingError::ParseError(_))));
+
+        let mut encoded = BytesMut::new();
+        codec.encode(package.clone(), &mut encoded).unwrap();
+
+        // Assert that the encoded bytes match the original buffer
+        assert_eq!(encoded.to_vec(), buffer);
+    }
+}

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,6 +1,6 @@
 use crate::message::{ProtocolMessage, HEADER};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ParseError {
     InvalidStartByte,
     IncompleteData,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,13 @@
+use crate::decoder;
+
+#[derive(Debug)]
+pub enum PingError {
+    Io(std::io::Error),
+    ParseError(decoder::ParseError),
+}
+
+impl From<std::io::Error> for PingError {
+    fn from(err: std::io::Error) -> PingError {
+        PingError::Io(err)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,9 @@ use crate::message::{DeserializeGenericMessage, HEADER};
 
 use std::convert::TryFrom;
 
+pub mod codec;
 pub mod decoder;
+pub mod error;
 pub mod message;
 
 pub fn calculate_crc(pack_without_payload: &[u8]) -> u16 {

--- a/src/message.rs
+++ b/src/message.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 pub const HEADER: [u8; 2] = ['B' as u8, 'R' as u8];
 
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ProtocolMessage {
     pub payload_length: u16,
     pub message_id: u16,

--- a/tests/async_codec.rs
+++ b/tests/async_codec.rs
@@ -1,0 +1,108 @@
+use futures::{SinkExt, StreamExt};
+use ping_rs::codec::PingCodec;
+use ping_rs::{common, message::ProtocolMessage, ping1d, Messages};
+use std::convert::TryFrom;
+use tokio::time::{sleep, Duration};
+use tokio_serial::SerialPortBuilderExt;
+use tokio_util::codec::{Decoder, Framed};
+
+async fn run_ping_test() -> Result<(), Box<dyn std::error::Error>> {
+    let mut port = tokio_serial::new("/dev/ttyUSB0", 115_200).open_native_async()?;
+    #[cfg(unix)]
+    port.set_exclusive(false)?;
+
+    let stream: Framed<tokio_serial::SerialStream, PingCodec> = PingCodec::new().framed(port);
+    let (mut tx, mut rx) = stream.split();
+
+    let request_id_list = [
+        1200, 1201, 1202, 1203, 1204, 1205, 1206, 1207, 1208, 1210, 1211, 1212, 1213, 1214, 1215,
+        1300,
+    ];
+
+    tokio::spawn(async move {
+        for request_id in request_id_list {
+            let request = common::Messages::GeneralRequest(common::GeneralRequestStruct {
+                requested_id: request_id,
+            });
+            let mut package = ProtocolMessage::new();
+            package.set_message(&request);
+
+            tx.send(package).await.unwrap();
+        }
+    });
+
+    for _n in 0..request_id_list.len() {
+        let item = rx
+            .next()
+            .await
+            .expect("Error awaiting future in RX stream.")
+            .expect("Reading stream resulted in an error");
+
+        assert!(item.has_valid_crc());
+
+        match Messages::try_from(&item) {
+            Ok(Messages::Ping1D(ping1d::Messages::FirmwareVersion(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::DeviceId(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::Voltage5(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::SpeedOfSound(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::Range(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::ModeAuto(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::PingInterval(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::GainSetting(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::TransmitDuration(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::GeneralInfo(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::DistanceSimple(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::Distance(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::ProcessorTemperature(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::PcbTemperature(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::PingEnable(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(Messages::Ping1D(ping1d::Messages::Profile(answer))) => {
+                println!("{answer:?}")
+            }
+            Ok(_) => {
+                panic!("Unexpected package. {:#?}", &item)
+            }
+            Err(e) => {
+                panic!("Error on decoder: {:?}", e)
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg_attr(not(feature = "local_runner"), ignore)]
+async fn test_run_ping_test() {
+    tokio::try_join!(run_ping_test()).unwrap();
+}


### PR DESCRIPTION
This fully implement codec structure using tokio_util Decoder/Encoder.

Add codec and error modules to src.

Codec have it's own tests.

There is an example/test using it with tokio runtime:
`cargo test --features local_runner 
`

Also fails with any panic as the one related in this [issue](https://github.com/bluerobotics/ping-rs/issues/16) for msg_id=1300.