### PR TITLE
Patrick idea for request

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,8 @@ build = "build/main.rs"
 [dependencies]
 bytes = "1.3.0"
 tokio-util = { version = "0.6.3", features = ["codec"] }
-
-[dev-dependencies]
-tokio-serial = "5.4.4"
 tokio = { version = "1.37.0", features = ["full"] }
+tokio-serial = "5.4.4"
 futures = "0.3.30"
 
 [build-dependencies]

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -443,11 +443,28 @@ pub fn generate<R: Read, W: Write>(input: &mut R, output_rust: &mut W) {
             quote!(#pascal_message_name(#pascal_struct_name),)
         })
         .collect::<Vec<TokenStream>>();
+
+    let message_enums_inner = messages
+        .iter()
+        .map(|(name, _message)| {
+            let pascal_message_name = ident!(name.to_case(Case::Pascal));
+            quote!(Self::#pascal_message_name(inner_struct) => (inner_struct as &dyn std::any::Any).downcast_ref::<T>(),)
+        })
+        .collect::<Vec<TokenStream>>();
+
     let message_enums = quote! {
         #[derive(Debug, Clone, PartialEq)]
         #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
         pub enum Messages {
             #(#message_enums)*
+        }
+
+        impl Messages {
+            pub fn inner<T: 'static>(&self) -> Option<&T> {
+                match self {
+                    #(#message_enums_inner)*
+                }
+            }
         }
     };
 

--- a/examples/ping_1d.rs
+++ b/examples/ping_1d.rs
@@ -1,0 +1,43 @@
+use ping_rs::device::{Ping1D, PingDevice};
+use ping_rs::error::PingError;
+use tokio_serial::SerialPortBuilderExt;
+
+#[tokio::main]
+async fn main() -> Result<(), PingError> {
+    let mut port = tokio_serial::new("/dev/ttyUSB1", 115200).open_native_async()?;
+    #[cfg(unix)]
+    port.set_exclusive(false)?;
+
+    let mut ping1d = Ping1D::new(port);
+
+    let mut subscribed = ping1d.subscribe();
+    tokio::spawn(async move {
+        loop {
+            let received = subscribed.recv().await;
+            match received {
+                Ok(msg) => println!("Subscribed channel received: \n Start: \n {msg:?} \n Ending"),
+                Err(_e) => break,
+            }
+        }
+    });
+
+    match ping1d.get_firmware().await {
+        Ok(version) => {
+            println!("Firmware version: {:?}", version);
+        }
+        Err(err) => {
+            eprintln!("Error getting firmware version: {:?}", err);
+        }
+    }
+
+    match ping1d.get_device_id().await {
+        Ok(version) => {
+            println!("Device id: {:?}", version);
+        }
+        Err(err) => {
+            eprintln!("Error getting firmware version: {:?}", err);
+        }
+    }
+
+    Ok(())
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,0 +1,202 @@
+use std::convert::TryFrom;
+
+use futures::{
+    stream::{SplitSink, SplitStream},
+    SinkExt, StreamExt,
+};
+use tokio::sync::{
+    broadcast::{self, Sender},
+    mpsc::{self, Receiver},
+};
+use tokio_serial::SerialStream;
+use tokio_util::codec::{Decoder, Framed};
+
+use crate::{
+    codec::PingCodec,
+    common::{self, ProtocolVersionStruct},
+    error::PingError,
+    message::{self, ProtocolMessage},
+    ping1d::{self, DeviceIdStruct},
+    Messages,
+};
+
+pub struct Common {
+    tx: mpsc::Sender<ProtocolMessage>,
+    rx: broadcast::Receiver<ProtocolMessage>,
+}
+
+impl Common {
+    pub fn new(port: tokio_serial::SerialStream) -> Result<Self, PingError> {
+        // Prepare Serial sink and stream modules
+        let serial: Framed<tokio_serial::SerialStream, PingCodec> = PingCodec::new().framed(port);
+        let (serial_sink, serial_stream) = serial.split();
+
+        // Prepare Serial receiver broadcast and sender
+        let (broadcast_tx, broadcast_rx) = broadcast::channel::<ProtocolMessage>(100);
+        tokio::spawn(Self::stream(serial_stream, broadcast_tx));
+        let (sender, sender_rx) = mpsc::channel::<ProtocolMessage>(100);
+        tokio::spawn(Self::sink(serial_sink, sender_rx));
+
+        Ok(Common {
+            tx: sender,
+            rx: broadcast_rx,
+        })
+    }
+
+    async fn sink(
+        mut sink: SplitSink<Framed<SerialStream, PingCodec>, ProtocolMessage>,
+        mut sender_rx: Receiver<ProtocolMessage>,
+    ) {
+        while let Some(item) = sender_rx.recv().await {
+            if let Err(_e) = sink.send(item).await {
+                break;
+            }
+        }
+    }
+
+    async fn stream(
+        mut serial_stream: SplitStream<Framed<SerialStream, PingCodec>>,
+        broadcast_tx: Sender<ProtocolMessage>,
+    ) {
+        loop {
+            while let Some(msg) = serial_stream.next().await {
+                if let Ok(msg) = msg {
+                    broadcast_tx.send(msg).unwrap();
+                }
+            }
+        }
+    }
+
+    pub async fn send_message(&self, message: ProtocolMessage) -> Result<(), PingError> {
+        match self.tx.send(message).await {
+            Ok(msg) => Ok(msg),
+            Err(err) => Err(PingError::TokioMpscError(err)),
+        }
+    }
+
+    pub async fn receive_message(&mut self) -> Result<ProtocolMessage, PingError> {
+        match self.rx.recv().await {
+            Ok(msg) => Ok(msg),
+            Err(err) => Err(PingError::TokioBroadcastError(err)),
+        }
+    }
+
+    fn subscribe(&self) -> tokio::sync::broadcast::Receiver<ProtocolMessage> {
+        self.rx.resubscribe()
+    }
+}
+
+pub trait PingDevice {
+    fn get_common(&self) -> &Common;
+
+    fn get_mut_common(&mut self) -> &mut Common;
+
+    fn subscribe(&mut self) -> tokio::sync::broadcast::Receiver<ProtocolMessage> {
+        self.get_mut_common().subscribe()
+    }
+
+    async fn send_general_request(
+        &mut self,
+        request_number: common::GeneralRequestStruct,
+    ) -> Result<(), PingError> {
+        let request = common::Messages::GeneralRequest(request_number);
+        let mut package = message::ProtocolMessage::new();
+        package.set_message(&request);
+
+        if let Err(e) = self.get_mut_common().send_message(package).await {
+            return Err(e);
+        };
+
+        Ok(())
+    }
+
+    async fn get_firmware(&mut self) -> Result<ProtocolVersionStruct, PingError> {
+        let mut receiver = self.subscribe();
+
+        let result = tokio::spawn(async move {
+            loop {
+                match receiver.recv().await {
+                    Ok(answer) => match Messages::try_from(&answer) {
+                        Ok(Messages::Common(common::Messages::ProtocolVersion(answer))) => {
+                            return Ok(answer)
+                        }
+                        _ => continue,
+                    },
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(e) => return Err(PingError::TokioBroadcastError(e)),
+                };
+            }
+        });
+
+        if let Err(e) = self
+            .send_general_request(common::GeneralRequestStruct { requested_id: 5 })
+            .await
+        {
+            return Err(e);
+        }
+
+        match tokio::time::timeout(tokio::time::Duration::from_millis(10000), result).await {
+            Ok(result) => match result {
+                Ok(result) => result,
+                Err(_) => Err(PingError::JoinError),
+            },
+            Err(_) => Err(PingError::TimeoutError),
+        }
+    }
+}
+
+pub struct Ping1D {
+    common: Common,
+}
+
+impl Ping1D {
+    pub fn new(port: tokio_serial::SerialStream) -> Self {
+        Self {
+            common: Common::new(port).unwrap(),
+        }
+    }
+
+    pub async fn get_device_id(&mut self) -> Result<DeviceIdStruct, PingError> {
+        let mut receiver = self.subscribe();
+
+        let result = tokio::spawn(async move {
+            loop {
+                match receiver.recv().await {
+                    Ok(answer) => match Messages::try_from(&answer) {
+                        Ok(Messages::Ping1D(ping1d::Messages::DeviceId(answer))) => {
+                            return Ok(answer)
+                        }
+                        _ => continue,
+                    },
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(e) => return Err(PingError::TokioBroadcastError(e)),
+                };
+            }
+        });
+
+        if let Err(e) = self
+            .send_general_request(common::GeneralRequestStruct { requested_id: 1201 })
+            .await
+        {
+            return Err(e);
+        }
+
+        match tokio::time::timeout(tokio::time::Duration::from_millis(10000), result).await {
+            Ok(result) => match result {
+                Ok(result) => result,
+                Err(_) => Err(PingError::JoinError),
+            },
+            Err(_) => Err(PingError::TimeoutError),
+        }
+    }
+}
+
+impl PingDevice for Ping1D {
+    fn get_common(&self) -> &Common {
+        &self.common
+    }
+
+    fn get_mut_common(&mut self) -> &mut Common {
+        &mut self.common
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,23 @@
-use crate::decoder;
+use crate::{decoder, message::ProtocolMessage};
 
 #[derive(Debug)]
 pub enum PingError {
     Io(std::io::Error),
     ParseError(decoder::ParseError),
+    TokioBroadcastError(tokio::sync::broadcast::error::RecvError),
+    TokioMpscError(tokio::sync::mpsc::error::SendError<ProtocolMessage>),
+    JoinError,
+    TimeoutError,
 }
 
 impl From<std::io::Error> for PingError {
     fn from(err: std::io::Error) -> PingError {
         PingError::Io(err)
+    }
+}
+
+impl From<tokio_serial::Error> for PingError {
+    fn from(err: tokio_serial::Error) -> PingError {
+        PingError::Io(std::io::Error::new(std::io::ErrorKind::Other, err))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use std::convert::TryFrom;
 
 pub mod codec;
 pub mod decoder;
+pub mod device;
 pub mod error;
 pub mod message;
 


### PR DESCRIPTION
@joaoantoniocardoso please take a look, the idea is to create a inner function for the parser/builder that uses the typesystem of structures to define a general request wait_for_message function.
With this, we don't need to create function for every single message, but using the typesystem to define all messages for us for free, based on the return type.
Check get_firmware for more an example. 