### PR TITLE
Add: Automatic function generation for get,set and control

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,14 @@ Testing set/get device id: 3
 Testing set/get device id: 2
 Testing set/get device id: 1
 Set gain to auto: true
+Test set & get with a new speed of sound: 343.0 m/s
+Test set & get with default speed of sound: 1500.0 m/s
 Protocol version is: 1.0.0
 Device id is: 1
+Gain setting is: 6
+Processor temperature is: 42.63 °C
+Voltage at 5V lane is: 5.006 V
+The distance to target is: 4538 mm
 Waiting for 30 profiles...
 Received 30 profiles
 Turning-off the continuous messages stream from Ping1D

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -579,10 +579,34 @@ pub fn generate<R: Read, W: Write>(input: &mut R, output_rust: &mut W) {
         use crate::message::SerializePayload;
         use crate::message::DeserializePayload;
         use crate::message::DeserializeGenericMessage;
+        use crate::device::Common;
+        use crate::device::PingDevice;
+        use crate::error::PingError;
+        use crate::message::ProtocolMessage;
         use std::convert::TryInto;
 
         #[cfg(feature = "serde")]
         use serde::{Deserialize, Serialize};
+
+        pub struct Device {
+            pub common: Common,
+        }
+
+        impl PingDevice for Device {
+            fn new(port: tokio_serial::SerialStream) -> Self {
+                Self {
+                    common: Common::new(port),
+                }
+            }
+
+            fn get_common(&self) -> &Common {
+                &self.common
+            }
+
+            fn get_mut_common(&mut self) -> &mut Common {
+                &mut self.common
+            }
+        }
 
         #protocol_wrapper
 

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -584,6 +584,7 @@ pub fn generate<R: Read, W: Write>(input: &mut R, output_rust: &mut W) {
         use crate::error::PingError;
         use crate::message::ProtocolMessage;
         use std::convert::TryInto;
+        use tokio::io::{AsyncRead, AsyncWrite};
 
         #[cfg(feature = "serde")]
         use serde::{Deserialize, Serialize};
@@ -593,12 +594,6 @@ pub fn generate<R: Read, W: Write>(input: &mut R, output_rust: &mut W) {
         }
 
         impl PingDevice for Device {
-            fn new(port: tokio_serial::SerialStream) -> Self {
-                Self {
-                    common: Common::new(port),
-                }
-            }
-
             fn get_common(&self) -> &Common {
                 &self.common
             }

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -142,10 +142,35 @@ struct MessageDefinition {
     id: u16,
     description: String,
     payload: Vec<Payload>,
+    category: MessageDefinitionCategory,
+}
+
+#[derive(Debug, PartialEq)]
+enum MessageDefinitionCategory {
+    Set,
+    Get,
+    Control,
+    General,
+}
+
+impl From<String> for MessageDefinitionCategory {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "set" => MessageDefinitionCategory::Set,
+            "get" => MessageDefinitionCategory::Get,
+            "control" => MessageDefinitionCategory::Control,
+            "general" => MessageDefinitionCategory::General,
+            _ => panic!("Invalid MessageDefinitionCategory: {}", s),
+        }
+    }
 }
 
 impl MessageDefinition {
-    pub fn from_json(name: &String, value: &serde_json::Value) -> Self {
+    pub fn from_json(
+        name: &String,
+        value: &serde_json::Value,
+        category: MessageDefinitionCategory,
+    ) -> Self {
         MessageDefinition {
             name: name.clone(),
             id: value.get("id").unwrap().as_u64().unwrap() as u16,
@@ -158,6 +183,7 @@ impl MessageDefinition {
                 .iter()
                 .map(|element| Payload::from_json(element))
                 .collect(),
+            category,
         }
     }
 
@@ -525,7 +551,11 @@ fn parse_description(
                         .map(|(message_name, value)| {
                             (
                                 message_name.clone(),
-                                MessageDefinition::from_json(message_name, value),
+                                MessageDefinition::from_json(
+                                    message_name,
+                                    value,
+                                    category.clone().into(),
+                                ),
                             )
                         })
                         .collect::<HashMap<String, MessageDefinition>>(),

--- a/examples/ping_1d.rs
+++ b/examples/ping_1d.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<(), PingError> {
     for n in (1..10).rev() {
         println!("Testing set/get device id: {n}");
         ping1d.set_device_id(n).await?;
-        assert_eq!(n, ping1d.get_device_id().await.unwrap().device_id);
+        assert_eq!(n, ping1d.device_id().await.unwrap().device_id);
     }
 
     // Testing set command, all set commands check for their Ack message, Error and NAck error are possible
@@ -64,12 +64,36 @@ async fn main() -> Result<(), PingError> {
         "Set gain to auto: {:?}",
         ping1d.set_mode_auto(1).await.is_ok()
     );
+    ping1d.set_speed_of_sound(343000).await?;
+    let mut speed_of_sound_struct = ping1d.speed_of_sound().await?;
+    println!(
+        "Test set & get with a new speed of sound: {:?} m/s",
+        speed_of_sound_struct.speed_of_sound as f64 / 1000.0
+    );
+    ping1d.set_speed_of_sound(1500000).await?;
+    speed_of_sound_struct = ping1d.speed_of_sound().await?;
+    println!(
+        "Test set & get with default speed of sound: {:?} m/s",
+        speed_of_sound_struct.speed_of_sound as f64 / 1000.0
+    );
 
-    // Creating two futures to read Protocol Version and Device ID
-    let res1 = async { ping1d.get_protocol_version().await };
-    let res2 = async { ping1d.get_device_id().await };
-    let (protocol_version_struct, device_id_struct) =
-        tokio::try_join!(res1, res2).expect("Failed to join results");
+    // Creating futures to read different device Properties
+    let (
+        protocol_version_struct,
+        device_id_struct,
+        gain_setting_struct,
+        processor_temperature_struct,
+        voltage5_struct,
+        distance_struct,
+    ) = tokio::try_join!(
+        ping1d.get_protocol_version(),
+        ping1d.device_id(),
+        ping1d.gain_setting(),
+        ping1d.processor_temperature(),
+        ping1d.voltage_5(),
+        ping1d.distance(),
+    )
+    .expect("Failed to join results");
 
     let version = format!(
         "{}.{}.{}",
@@ -80,6 +104,19 @@ async fn main() -> Result<(), PingError> {
 
     println!("Protocol version is: {version}");
     println!("Device id is: {:?}", device_id_struct.device_id);
+    println!("Gain setting is: {:?}", gain_setting_struct.gain_setting);
+    println!(
+        "Processor temperature is: {:.2} °C",
+        processor_temperature_struct.processor_temperature as f64 / 100.0
+    );
+    println!(
+        "Voltage at 5V lane is: {:.3} V",
+        voltage5_struct.voltage_5 as f64 / 1000.0
+    );
+    println!(
+        "The distance to target is: {:?} mm",
+        distance_struct.distance
+    );
 
     // Read the 30 packages we are waiting since the start of this example, all above tasks have success, we did it!
     println!("Waiting for 30 profiles...");


### PR DESCRIPTION
Requirements:

- [ x] https://github.com/bluerobotics/ping-rs/pull/32
- [ x] https://github.com/bluerobotics/ping-rs/pull/33

This PR adds an enum 'category' to make it easier to compose each kind of function. 
All the functions related to ping1d/ping360 are now auto-generated.

The functions' set has the parameters exactly as "Set-any-structures". Each **set function** has a subscriber which waits until receiving its corresponding Ack code or error. 
Each **setting function** simply sends the corresponding request (Ack codes after setting request weren't observed). Each **get function** has its own subscriber that waits to match the corresponding structure. Functions also have their descriptions.

All the logic towards sending, subscribing, receiving with ack check, and timeout remains the same and is defined in PingDevice.

The Ping1D has been moved to a builder and is now ping1d::Device. ping1D::Device is reimported as Ping1D, as is Ping360 which actually has all functions attached to it.

![image](https://github.com/bluerobotics/ping-rs/assets/80598030/4e674651-582d-4e81-a3ed-ae68d87ba6ee)

Next steps:

- [ ] - Add function inputs description and their unities;
- [ ] - Modify the Device structure back to device.rs and allow custom ones;
