### PR TITLE
Fix: build: parser: NAck decoding

### DIFF
--- a/build/parser.rs
+++ b/build/parser.rs
@@ -406,7 +406,7 @@ impl MessageDefinition {
                         } else {
                             let length = self.payload.len();
                             let field_token = quote! {
-                                #name: String::from_utf8(payload[#b..#b + payload.len()].to_vec()).unwrap(),
+                                #name: String::from_utf8(payload[#b..payload.len()].to_vec()).unwrap(),
                             };
                             b += length;
                             field_token


### PR DESCRIPTION
Fix the following error from NAck packages:
```
Waiting for 30 profiles...
Start watcher
Received Protocol message: ProtocolMessage { payload_length: 22, message_id: 2, src_device_id: 1, dst_device_id: 0, payload: [41, 10, 117, 110, 104, 97, 110, 100, 108, 101, 100, 32, 112, 97, 99, 107, 101, 116, 32, 105, 100, 0], checksum: 2072 }
ProtocolMessage { payload_length: 22, message_id: 2, src_device_id: 1, dst_device_id: 0, payload: [41, 10, 117, 110, 104, 97, 110, 100, 108, 101, 100, 32, 112, 97, 99, 107, 101, 116, 32, 105, 100, 0], checksum: 2072 }
thread 'tokio-runtime-worker' panicked at /target/armv7-unknown-linux-gnueabihf/release/build/bluerobotics-ping-63ecf9a76962df2f/out/common.rs:221:52:
range end index 24 out of range for slice of length 22
stack backtrace:
   0: rust_begin_unwind
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/std/src/panicking.rs:647:5
   1: core::panicking::panic_fmt
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/panicking.rs:72:14
   2: core::slice::index::slice_end_index_len_fail_rt
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/slice/index.rs:76:5
   3: core::slice::index::slice_end_index_len_fail
             at /rustc/25ef9e3d85d934b27d9dada2f9dd52b1dc63bb04/library/core/src/slice/index.rs:68:9
   4: <bluerobotics_ping::common::Messages as bluerobotics_ping::message::DeserializeGenericMessage>::deserialize
   5: <bluerobotics_ping::Messages as core::convert::TryFrom<&bluerobotics_ping::message::ProtocolMessage>>::try_from
   6: ping_1d::main::{{closure}}::{{closure}}
   7: tokio::runtime::task::core::Core<T,S>::poll
   8: tokio::runtime::task::harness::Harness<T,S>::poll
   9: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
  10: tokio::runtime::scheduler::multi_thread::worker::Context::run
  11: tokio::runtime::context::set_scheduler
  12: tokio::runtime::context::runtime::enter_runtime
  13: tokio::runtime::scheduler::multi_thread::worker::run
  14: tokio::runtime::task::core::Core<T,S>::poll
  15: tokio::runtime::task::harness::Harness<T,S>::poll
  16: tokio::runtime::blocking::pool::Inner::run
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
The oneshot sender dropped
```

fixed:
```
Parsing user provided values and creating port...
Using serial port: "/dev/ttyUSB0"
Creating your Ping 1D device
Waiting for 30 profiles...
Start watcher
Received Protocol message: ProtocolMessage { payload_length: 22, message_id: 2, src_device_id: 1, dst_device_id: 0, payload: [41, 10, 117, 110, 104, 97, 110, 100, 108, 101, 100, 32, 112, 97, 99, 107, 101, 116, 32, 105, 100, 0], checksum: 2072 }
ProtocolMessage { payload_length: 22, message_id: 2, src_device_id: 1, dst_device_id: 0, payload: [41, 10, 117, 110, 104, 97, 110, 100, 108, 101, 100, 32, 112, 97, 99, 107, 101, 116, 32, 105, 100, 0], checksum: 2072 }
NackStruct { nacked_id: 2601, nack_message: "unhandled packet id\0" }


```